### PR TITLE
Implement melee projectile mana cost

### DIFF
--- a/Localization/en-US_Mods.ProgressionReforged.hjson
+++ b/Localization/en-US_Mods.ProgressionReforged.hjson
@@ -193,6 +193,7 @@ PrefixUpgrade: {
 }
 
 HeavyWorkBenchTooltip: Upgrades equipment prefixes
+MeleeProjectileManaTooltip: Uses {0} mana to fire a projectile
 
 Buffs: {
 	PrefixWhipTagDamageBuff: {

--- a/Systems/MeleeProjectileMana/IMeleeProjectileManaCostProvider.cs
+++ b/Systems/MeleeProjectileMana/IMeleeProjectileManaCostProvider.cs
@@ -1,0 +1,6 @@
+namespace ProgressionReforged.Systems.MeleeProjectileMana;
+
+public interface IMeleeProjectileManaCostProvider
+{
+    int ProjectileManaCost { get; }
+}

--- a/Systems/MeleeProjectileMana/MeleeProjectileManaGlobalItem.cs
+++ b/Systems/MeleeProjectileMana/MeleeProjectileManaGlobalItem.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.DataStructures;
+using Terraria.ID;
+using Terraria.Localization;
+using Terraria.ModLoader;
+
+namespace ProgressionReforged.Systems.MeleeProjectileMana;
+
+public class MeleeProjectileManaGlobalItem : GlobalItem
+{
+    private const float DamageFactor = 0.1f;
+    private const float UseTimeFactor = 0.05f;
+    private const float ScaleFactor = 1.5f;
+
+    private static int GetManaCost(Item item)
+    {
+        if (item.ModItem is IMeleeProjectileManaCostProvider provider)
+            return provider.ProjectileManaCost;
+
+        float cost = item.damage * DamageFactor + item.useTime * UseTimeFactor + item.scale * ScaleFactor;
+        return Math.Max(1, (int)MathF.Round(cost));
+    }
+
+    public override bool AppliesToEntity(Item item, bool lateInstantiation)
+    {
+        return item.DamageType == DamageClass.Melee && item.shoot > ProjectileID.None;
+    }
+
+    public override bool Shoot(Item item, Player player, EntitySource_ItemUse_WithAmmo source,
+        Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+    {
+        int cost = GetManaCost(item);
+        if (!player.CheckMana(cost, true))
+            return false;
+
+        return true;
+    }
+
+    public override void ModifyTooltips(Item item, List<TooltipLine> tooltips)
+    {
+        int cost = GetManaCost(item);
+        string text = Language.GetTextValue("Mods.ProgressionReforged.MeleeProjectileManaTooltip", cost);
+        tooltips.Add(new TooltipLine(Mod, "MeleeProjectileManaTooltip", text));
+    }
+}


### PR DESCRIPTION
## Summary
- add `IMeleeProjectileManaCostProvider` for overriding projectile mana cost
- implement `MeleeProjectileManaGlobalItem` to charge mana when melee weapons fire projectiles
- localize tooltip for new mana mechanic

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea67797f0832cb7ddb33e2aefb4f4