### PR TITLE
Fix Soulbound Cache zero-length normalization crash

### DIFF
--- a/Content/Projectiles/SoulboundCache.cs
+++ b/Content/Projectiles/SoulboundCache.cs
@@ -40,10 +40,16 @@ public class SoulboundCache : ModProjectile
         if (Projectile.ai[1] == 0f)
         {
             Vector2 target = new((tileX + 0.5f) * 16f, (tileY - 2f) * 16f - 22f);
-            
+            Vector2 toTarget = target - Projectile.Center;
+            float distance = toTarget.Length();
+
             // steer towards the target each tick
-            Projectile.velocity = Projectile.DirectionTo(target) * 2f;
-            if (Vector2.Distance(Projectile.Center, target) < 4f)
+            if (distance > 4f)
+            {
+                if (distance > 0f)
+                    Projectile.velocity = toTarget / distance * 2f;
+            }
+            else
             {
                 Projectile.Center = target;
                 Projectile.velocity = Vector2.Zero;

--- a/Systems/Mediumcore/MediumcoreDropSystem.cs
+++ b/Systems/Mediumcore/MediumcoreDropSystem.cs
@@ -108,11 +108,14 @@ internal class MediumcoreDropSystem : ModSystem
         tag["tileY"] = y;
 
         Vector2 spawnPos = fromWorldLoad ? finalPos : origin;
-        Vector2 velocity = Vector2.Normalize(finalPos - origin);
-        if (!velocity.HasNaNs())
-            velocity *= fromWorldLoad ? 0f : 2f;
-        else
-            velocity = Vector2.Zero;
+        Vector2 velocity = Vector2.Zero;
+        if (!fromWorldLoad)
+        {
+            Vector2 offset = finalPos - origin;
+            float distance = offset.Length();
+            if (distance > 0f)
+                velocity = offset / distance * 2f;
+        }
         
         if (fromWorldLoad && !Framing.GetTileSafely(x, y).HasTile)
             WorldGen.PlaceTile(x, y, ModContent.TileType<Content.Tiles.SoulboundCache>(), false, true);


### PR DESCRIPTION
## Summary
- stop normalizing zero-length vectors while steering the Soulbound Cache projectile so it can reach its tile without crashing
- avoid normalizing the zero-length travel vector when spawning the cache from stored data

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e29b6b40d4832cbca801cd0a723160