### PR TITLE
Add life crystal counting command

### DIFF
--- a/Localization/en-US_Mods.ProgressionReforged.hjson
+++ b/Localization/en-US_Mods.ProgressionReforged.hjson
@@ -214,3 +214,15 @@ Buffs: {
 }
 
 Projectiles.SoulboundCache.DisplayName: Soulbound Cache
+
+LifeCrystals: {
+        NotEnough: You need {0} life crystal(s) to increase your max life.
+        BossReward: {0} new life crystal(s) have formed underground!
+        Tooltip: {
+                NextCost: Next heart requires {0} life crystal(s). You have {1}.
+        }
+        Command: {
+                WorldCount: There are {0} life crystals in the world.
+                NextCost: Your next heart requires {0} life crystal(s). You have {1}.
+        }
+}

--- a/ProgressionReforgedConfig.cs
+++ b/ProgressionReforgedConfig.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel;
+using Terraria.ModLoader;
+using Terraria.ModLoader.Config;
+
+namespace ProgressionReforged;
+
+public class ProgressionReforgedConfig : ModConfig
+{
+    public static ProgressionReforgedConfig Instance => ModContent.GetInstance<ProgressionReforgedConfig>();
+
+    public override ConfigScope Mode => ConfigScope.ServerSide;
+
+    [Header("Life Crystal Availability")]
+    [Label("Initial life crystal density multiplier")]
+    [Range(0f, 1f)]
+    [DefaultValue(0.2f)]
+    public float InitialLifeCrystalMultiplier { get; set; } = 0.2f;
+
+    [Header("Life Crystal Costs")]
+    [Label("Base life crystal cost per heart")] 
+    [Range(1, 10)]
+    [DefaultValue(1)]
+    public int LifeCrystalBaseCost { get; set; } = 1;
+
+    [Label("Hearts added before cost increases")]
+    [Tooltip("How many heart upgrades share the same cost before the cost increases again.")]
+    [Range(1, 10)]
+    [DefaultValue(2)]
+    public int LifeCrystalCostIncreaseFrequency { get; set; } = 2;
+
+    [Label("Additional crystals added to the cost each step")]
+    [Range(0, 10)]
+    [DefaultValue(1)]
+    public int LifeCrystalCostIncreaseAmount { get; set; } = 1;
+
+    [Header("Boss Life Crystal Rewards")]
+    [Label("King Slime reward crystals")]
+    [Range(0, 30)]
+    [DefaultValue(5)]
+    public int KingSlimeLifeCrystals { get; set; } = 5;
+
+    [Label("Eye of Cthulhu reward crystals")]
+    [Range(0, 30)]
+    [DefaultValue(5)]
+    public int EyeOfCthulhuLifeCrystals { get; set; } = 5;
+
+    [Label("Eater of Worlds reward crystals")]
+    [Range(0, 30)]
+    [DefaultValue(6)]
+    public int EaterOfWorldsLifeCrystals { get; set; } = 6;
+
+    [Label("Brain of Cthulhu reward crystals")]
+    [Range(0, 30)]
+    [DefaultValue(6)]
+    public int BrainOfCthulhuLifeCrystals { get; set; } = 6;
+
+    [Label("Skeletron reward crystals")]
+    [Range(0, 30)]
+    [DefaultValue(8)]
+    public int SkeletronLifeCrystals { get; set; } = 8;
+}

--- a/Systems/LifeCrystals/LifeCrystalCountCommand.cs
+++ b/Systems/LifeCrystals/LifeCrystalCountCommand.cs
@@ -1,0 +1,21 @@
+using Microsoft.Xna.Framework;
+using Terraria.ModLoader;
+
+namespace ProgressionReforged.Systems.LifeCrystals;
+
+internal sealed class LifeCrystalCountCommand : ModCommand
+{
+    public override CommandType Type => CommandType.World;
+
+    public override string Command => "countlifecrystals";
+
+    public override string Usage => "/countlifecrystals";
+
+    public override string Description => "Displays the number of life crystals currently in the world.";
+
+    public override void Action(CommandCaller caller, string input, string[] args)
+    {
+        int count = LifeCrystalSystem.CountLifeCrystals();
+        caller.Reply($"There are {count} life crystals in the world.", Color.Orange);
+    }
+}

--- a/Systems/LifeCrystals/LifeCrystalCountCommand.cs
+++ b/Systems/LifeCrystals/LifeCrystalCountCommand.cs
@@ -1,4 +1,7 @@
 using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace ProgressionReforged.Systems.LifeCrystals;
@@ -16,6 +19,15 @@ internal sealed class LifeCrystalCountCommand : ModCommand
     public override void Action(CommandCaller caller, string input, string[] args)
     {
         int count = LifeCrystalSystem.CountLifeCrystals();
-        caller.Reply($"There are {count} life crystals in the world.", Color.Orange);
+        string worldCount = Language.GetTextValue("Mods.ProgressionReforged.LifeCrystals.Command.WorldCount", count);
+        caller.Reply(worldCount, Color.Orange);
+
+        if (caller.Player is Player player)
+        {
+            int required = LifeCrystalSystem.GetLifeCrystalCostForNextHeart(player);
+            int available = player.CountItem(ItemID.LifeCrystal);
+            string nextCost = Language.GetTextValue("Mods.ProgressionReforged.LifeCrystals.Command.NextCost", required, available);
+            caller.Reply(nextCost, Color.Orange);
+        }
     }
 }

--- a/Systems/LifeCrystals/LifeCrystalGlobalItem.cs
+++ b/Systems/LifeCrystals/LifeCrystalGlobalItem.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using Terraria;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace ProgressionReforged.Systems.LifeCrystals;
@@ -28,7 +30,18 @@ internal sealed class LifeCrystalGlobalItem : GlobalItem
         player.GetModPlayer<LifeCrystalPlayer>().PendingLifeCrystalCost = required;
         int available = player.CountItem(ItemID.LifeCrystal);
 
-        return available >= required;
+        if (available >= required)
+        {
+            return true;
+        }
+
+        if (player.whoAmI == Main.myPlayer && Main.netMode != NetmodeID.Server)
+        {
+            string message = Language.GetTextValue("Mods.ProgressionReforged.LifeCrystals.NotEnough", required);
+            Main.NewText(message, 255, 240, 20);
+        }
+
+        return false;
     }
 
     public override void OnConsumeItem(Item item, Player player)
@@ -47,5 +60,25 @@ internal sealed class LifeCrystalGlobalItem : GlobalItem
         }
 
         player.ConsumeItem(ItemID.LifeCrystal, required);
+    }
+
+    public override void ModifyTooltips(Item item, List<TooltipLine> tooltips)
+    {
+        if (item.type != ItemID.LifeCrystal)
+        {
+            return;
+        }
+
+        Player player = Main.LocalPlayer;
+        if (player is null)
+        {
+            return;
+        }
+
+        int required = LifeCrystalSystem.GetLifeCrystalCostForNextHeart(player);
+        int available = player.CountItem(ItemID.LifeCrystal);
+
+        string text = Language.GetTextValue("Mods.ProgressionReforged.LifeCrystals.Tooltip.NextCost", required, available);
+        tooltips.Add(new TooltipLine(Mod, "ProgressionReforged_LifeCrystalCost", text));
     }
 }

--- a/Systems/LifeCrystals/LifeCrystalGlobalItem.cs
+++ b/Systems/LifeCrystals/LifeCrystalGlobalItem.cs
@@ -1,0 +1,51 @@
+using System;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace ProgressionReforged.Systems.LifeCrystals;
+
+internal sealed class LifeCrystalGlobalItem : GlobalItem
+{
+    public override bool AppliesToEntity(Item entity, bool lateInstantiation)
+    {
+        return entity.type == ItemID.LifeCrystal;
+    }
+
+    public override bool CanUseItem(Item item, Player player)
+    {
+        if (!base.CanUseItem(item, player))
+        {
+            return false;
+        }
+
+        if (!player.CanConsumeLifeCrystal())
+        {
+            return false;
+        }
+
+        int required = LifeCrystalSystem.GetLifeCrystalCostForNextHeart(player);
+        player.GetModPlayer<LifeCrystalPlayer>().PendingLifeCrystalCost = required;
+        int available = player.CountItem(ItemID.LifeCrystal);
+
+        return available >= required;
+    }
+
+    public override void OnConsumeItem(Item item, Player player)
+    {
+        if (item.type != ItemID.LifeCrystal)
+        {
+            return;
+        }
+
+        int required = Math.Max(0, player.GetModPlayer<LifeCrystalPlayer>().PendingLifeCrystalCost - 1);
+        player.GetModPlayer<LifeCrystalPlayer>().PendingLifeCrystalCost = 1;
+
+        if (required <= 0)
+        {
+            return;
+        }
+
+        player.ConsumeItem(ItemID.LifeCrystal, required);
+    }
+}

--- a/Systems/LifeCrystals/LifeCrystalPlayer.cs
+++ b/Systems/LifeCrystals/LifeCrystalPlayer.cs
@@ -1,0 +1,8 @@
+using Terraria.ModLoader;
+
+namespace ProgressionReforged.Systems.LifeCrystals;
+
+internal sealed class LifeCrystalPlayer : ModPlayer
+{
+    public int PendingLifeCrystalCost { get; set; } = 1;
+}

--- a/Systems/LifeCrystals/LifeCrystalSystem.cs
+++ b/Systems/LifeCrystals/LifeCrystalSystem.cs
@@ -1,8 +1,12 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework;
 using Terraria;
+using Terraria.Chat;
 using Terraria.DataStructures;
+using Terraria.Enums;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 using Terraria.Utilities;
@@ -11,19 +15,37 @@ namespace ProgressionReforged.Systems.LifeCrystals;
 
 internal sealed class LifeCrystalSystem : ModSystem
 {
-    private bool _kingSlimeRewardGiven;
-    private bool _eyeOfCthulhuRewardGiven;
-    private bool _eaterOfWorldsRewardGiven;
-    private bool _brainOfCthulhuRewardGiven;
-    private bool _skeletronRewardGiven;
+    private bool _kingSlimeRewardUnlocked;
+    private int _kingSlimePendingCrystals;
+
+    private bool _eyeOfCthulhuRewardUnlocked;
+    private int _eyeOfCthulhuPendingCrystals;
+
+    private bool _eaterOfWorldsRewardUnlocked;
+    private int _eaterOfWorldsPendingCrystals;
+
+    private bool _brainOfCthulhuRewardUnlocked;
+    private int _brainOfCthulhuPendingCrystals;
+
+    private bool _skeletronRewardUnlocked;
+    private int _skeletronPendingCrystals;
 
     public override void OnWorldLoad()
     {
-        _kingSlimeRewardGiven = false;
-        _eyeOfCthulhuRewardGiven = false;
-        _eaterOfWorldsRewardGiven = false;
-        _brainOfCthulhuRewardGiven = false;
-        _skeletronRewardGiven = false;
+        _kingSlimeRewardUnlocked = false;
+        _kingSlimePendingCrystals = 0;
+
+        _eyeOfCthulhuRewardUnlocked = false;
+        _eyeOfCthulhuPendingCrystals = 0;
+
+        _eaterOfWorldsRewardUnlocked = false;
+        _eaterOfWorldsPendingCrystals = 0;
+
+        _brainOfCthulhuRewardUnlocked = false;
+        _brainOfCthulhuPendingCrystals = 0;
+
+        _skeletronRewardUnlocked = false;
+        _skeletronPendingCrystals = 0;
     }
 
     public override void OnWorldUnload()
@@ -33,20 +55,73 @@ internal sealed class LifeCrystalSystem : ModSystem
 
     public override void LoadWorldData(TagCompound tag)
     {
-        _kingSlimeRewardGiven = tag.GetBool(nameof(_kingSlimeRewardGiven));
-        _eyeOfCthulhuRewardGiven = tag.GetBool(nameof(_eyeOfCthulhuRewardGiven));
-        _eaterOfWorldsRewardGiven = tag.GetBool(nameof(_eaterOfWorldsRewardGiven));
-        _brainOfCthulhuRewardGiven = tag.GetBool(nameof(_brainOfCthulhuRewardGiven));
-        _skeletronRewardGiven = tag.GetBool(nameof(_skeletronRewardGiven));
+        if (tag.ContainsKey(nameof(_kingSlimeRewardUnlocked)))
+        {
+            _kingSlimeRewardUnlocked = tag.GetBool(nameof(_kingSlimeRewardUnlocked));
+        }
+
+        if (tag.ContainsKey(nameof(_kingSlimePendingCrystals)))
+        {
+            _kingSlimePendingCrystals = Math.Max(0, tag.GetInt(nameof(_kingSlimePendingCrystals)));
+        }
+
+        if (tag.ContainsKey(nameof(_eyeOfCthulhuRewardUnlocked)))
+        {
+            _eyeOfCthulhuRewardUnlocked = tag.GetBool(nameof(_eyeOfCthulhuRewardUnlocked));
+        }
+
+        if (tag.ContainsKey(nameof(_eyeOfCthulhuPendingCrystals)))
+        {
+            _eyeOfCthulhuPendingCrystals = Math.Max(0, tag.GetInt(nameof(_eyeOfCthulhuPendingCrystals)));
+        }
+
+        if (tag.ContainsKey(nameof(_eaterOfWorldsRewardUnlocked)))
+        {
+            _eaterOfWorldsRewardUnlocked = tag.GetBool(nameof(_eaterOfWorldsRewardUnlocked));
+        }
+
+        if (tag.ContainsKey(nameof(_eaterOfWorldsPendingCrystals)))
+        {
+            _eaterOfWorldsPendingCrystals = Math.Max(0, tag.GetInt(nameof(_eaterOfWorldsPendingCrystals)));
+        }
+
+        if (tag.ContainsKey(nameof(_brainOfCthulhuRewardUnlocked)))
+        {
+            _brainOfCthulhuRewardUnlocked = tag.GetBool(nameof(_brainOfCthulhuRewardUnlocked));
+        }
+
+        if (tag.ContainsKey(nameof(_brainOfCthulhuPendingCrystals)))
+        {
+            _brainOfCthulhuPendingCrystals = Math.Max(0, tag.GetInt(nameof(_brainOfCthulhuPendingCrystals)));
+        }
+
+        if (tag.ContainsKey(nameof(_skeletronRewardUnlocked)))
+        {
+            _skeletronRewardUnlocked = tag.GetBool(nameof(_skeletronRewardUnlocked));
+        }
+
+        if (tag.ContainsKey(nameof(_skeletronPendingCrystals)))
+        {
+            _skeletronPendingCrystals = Math.Max(0, tag.GetInt(nameof(_skeletronPendingCrystals)));
+        }
     }
 
     public override void SaveWorldData(TagCompound tag)
     {
-        tag[nameof(_kingSlimeRewardGiven)] = _kingSlimeRewardGiven;
-        tag[nameof(_eyeOfCthulhuRewardGiven)] = _eyeOfCthulhuRewardGiven;
-        tag[nameof(_eaterOfWorldsRewardGiven)] = _eaterOfWorldsRewardGiven;
-        tag[nameof(_brainOfCthulhuRewardGiven)] = _brainOfCthulhuRewardGiven;
-        tag[nameof(_skeletronRewardGiven)] = _skeletronRewardGiven;
+        tag[nameof(_kingSlimeRewardUnlocked)] = _kingSlimeRewardUnlocked;
+        tag[nameof(_kingSlimePendingCrystals)] = _kingSlimePendingCrystals;
+
+        tag[nameof(_eyeOfCthulhuRewardUnlocked)] = _eyeOfCthulhuRewardUnlocked;
+        tag[nameof(_eyeOfCthulhuPendingCrystals)] = _eyeOfCthulhuPendingCrystals;
+
+        tag[nameof(_eaterOfWorldsRewardUnlocked)] = _eaterOfWorldsRewardUnlocked;
+        tag[nameof(_eaterOfWorldsPendingCrystals)] = _eaterOfWorldsPendingCrystals;
+
+        tag[nameof(_brainOfCthulhuRewardUnlocked)] = _brainOfCthulhuRewardUnlocked;
+        tag[nameof(_brainOfCthulhuPendingCrystals)] = _brainOfCthulhuPendingCrystals;
+
+        tag[nameof(_skeletronRewardUnlocked)] = _skeletronRewardUnlocked;
+        tag[nameof(_skeletronPendingCrystals)] = _skeletronPendingCrystals;
     }
 
     public override void PostWorldGen()
@@ -63,11 +138,11 @@ internal sealed class LifeCrystalSystem : ModSystem
 
         var config = ProgressionReforgedConfig.Instance;
 
-        TryGrantBossReward(ref _kingSlimeRewardGiven, NPC.downedSlimeKing, config.KingSlimeLifeCrystals);
-        TryGrantBossReward(ref _eyeOfCthulhuRewardGiven, NPC.downedBoss1, config.EyeOfCthulhuLifeCrystals);
-        TryGrantBossReward(ref _eaterOfWorldsRewardGiven, NPC.downedBoss2 && WorldGen.crimson != true, config.EaterOfWorldsLifeCrystals);
-        TryGrantBossReward(ref _brainOfCthulhuRewardGiven, NPC.downedBoss2 && WorldGen.crimson, config.BrainOfCthulhuLifeCrystals);
-        TryGrantBossReward(ref _skeletronRewardGiven, NPC.downedBoss3, config.SkeletronLifeCrystals);
+        ProcessBossReward(ref _kingSlimeRewardUnlocked, ref _kingSlimePendingCrystals, NPC.downedSlimeKing, config.KingSlimeLifeCrystals);
+        ProcessBossReward(ref _eyeOfCthulhuRewardUnlocked, ref _eyeOfCthulhuPendingCrystals, NPC.downedBoss1, config.EyeOfCthulhuLifeCrystals);
+        ProcessBossReward(ref _eaterOfWorldsRewardUnlocked, ref _eaterOfWorldsPendingCrystals, NPC.downedBoss2 && !WorldGen.crimson, config.EaterOfWorldsLifeCrystals);
+        ProcessBossReward(ref _brainOfCthulhuRewardUnlocked, ref _brainOfCthulhuPendingCrystals, NPC.downedBoss2 && WorldGen.crimson, config.BrainOfCthulhuLifeCrystals);
+        ProcessBossReward(ref _skeletronRewardUnlocked, ref _skeletronPendingCrystals, NPC.downedBoss3, config.SkeletronLifeCrystals);
     }
 
     public static int CountLifeCrystals()
@@ -149,24 +224,33 @@ internal sealed class LifeCrystalSystem : ModSystem
         NetMessage.SendTileSquare(-1, topLeft.X + 1, topLeft.Y + 1, 2);
     }
 
-    private void TryGrantBossReward(ref bool flag, bool conditionMet, int amount)
+    private void ProcessBossReward(ref bool unlocked, ref int pendingCrystals, bool conditionMet, int configuredAmount)
     {
-        if (flag || !conditionMet || amount <= 0)
+        if (conditionMet && !unlocked)
+        {
+            unlocked = true;
+            pendingCrystals += Math.Max(0, configuredAmount);
+        }
+
+        if (pendingCrystals <= 0)
         {
             return;
         }
 
-        int placed = SpawnLifeCrystals(amount);
+        int attemptCount = Math.Min(pendingCrystals, 5);
+        int placed = SpawnLifeCrystals(attemptCount);
+
         if (placed > 0)
         {
-            flag = true;
+            pendingCrystals -= placed;
+            AnnounceLifeCrystalsSpawned(placed);
         }
     }
 
     private int SpawnLifeCrystals(int amount)
     {
         int placed = 0;
-        var attemptsPerCrystal = 3000;
+        const int attemptsPerCrystal = 3000;
         for (int i = 0; i < amount; i++)
         {
             if (TryPlaceLifeCrystal(attemptsPerCrystal))
@@ -199,6 +283,11 @@ internal sealed class LifeCrystalSystem : ModSystem
 
             if (WorldGen.PlaceTile(x, y, TileID.Heart, mute: true, forced: true))
             {
+                WorldGen.SquareTileFrame(x, y, resetFrame: true);
+                WorldGen.SquareTileFrame(x + 1, y, resetFrame: true);
+                WorldGen.SquareTileFrame(x, y + 1, resetFrame: true);
+                WorldGen.SquareTileFrame(x + 1, y + 1, resetFrame: true);
+
                 NetMessage.SendTileSquare(-1, x + 1, y + 1, 2);
                 return true;
             }
@@ -219,23 +308,52 @@ internal sealed class LifeCrystalSystem : ModSystem
             for (int j = 0; j < 2; j++)
             {
                 Tile tile = Framing.GetTileSafely(x + i, y + j);
-                if (tile.HasTile)
+                if (tile.HasTile || tile.LiquidAmount > 0 || tile.IsActuated)
                 {
                     return false;
                 }
             }
         }
 
-        for (int i = -1; i <= 2; i++)
+        Tile belowLeft = Framing.GetTileSafely(x, y + 2);
+        Tile belowRight = Framing.GetTileSafely(x + 1, y + 2);
+
+        return IsSupportingTile(belowLeft) && IsSupportingTile(belowRight);
+    }
+
+    private static bool IsSupportingTile(Tile tile)
+    {
+        if (!tile.HasTile || tile.IsActuated)
         {
-            Tile below = Framing.GetTileSafely(x + i, y + 2);
-            if (below.HasTile && Main.tileSolid[below.TileType])
-            {
-                return true;
-            }
+            return false;
         }
 
-        return false;
+        if (!Main.tileSolid[tile.TileType])
+        {
+            return false;
+        }
+
+        return tile.Slope == SlopeType.Solid;
+    }
+
+    private static void AnnounceLifeCrystalsSpawned(int amount)
+    {
+        if (amount <= 0)
+        {
+            return;
+        }
+
+        string message = Language.GetTextValue("Mods.ProgressionReforged.LifeCrystals.BossReward", amount);
+        Color color = new(255, 240, 20);
+
+        if (Main.netMode == NetmodeID.Server)
+        {
+            ChatHelper.BroadcastChatMessage(NetworkText.FromLiteral(message), color);
+        }
+        else
+        {
+            Main.NewText(message, color.R, color.G, color.B);
+        }
     }
 
     public static int GetLifeCrystalCostForNextHeart(Player player)

--- a/Systems/LifeCrystals/LifeCrystalSystem.cs
+++ b/Systems/LifeCrystals/LifeCrystalSystem.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using Terraria;
+using Terraria.DataStructures;
+using Terraria.ID;
+using Terraria.ModLoader;
+using Terraria.ModLoader.IO;
+using Terraria.Utilities;
+
+namespace ProgressionReforged.Systems.LifeCrystals;
+
+internal sealed class LifeCrystalSystem : ModSystem
+{
+    private bool _kingSlimeRewardGiven;
+    private bool _eyeOfCthulhuRewardGiven;
+    private bool _eaterOfWorldsRewardGiven;
+    private bool _brainOfCthulhuRewardGiven;
+    private bool _skeletronRewardGiven;
+
+    public override void OnWorldLoad()
+    {
+        _kingSlimeRewardGiven = false;
+        _eyeOfCthulhuRewardGiven = false;
+        _eaterOfWorldsRewardGiven = false;
+        _brainOfCthulhuRewardGiven = false;
+        _skeletronRewardGiven = false;
+    }
+
+    public override void OnWorldUnload()
+    {
+        OnWorldLoad();
+    }
+
+    public override void LoadWorldData(TagCompound tag)
+    {
+        _kingSlimeRewardGiven = tag.GetBool(nameof(_kingSlimeRewardGiven));
+        _eyeOfCthulhuRewardGiven = tag.GetBool(nameof(_eyeOfCthulhuRewardGiven));
+        _eaterOfWorldsRewardGiven = tag.GetBool(nameof(_eaterOfWorldsRewardGiven));
+        _brainOfCthulhuRewardGiven = tag.GetBool(nameof(_brainOfCthulhuRewardGiven));
+        _skeletronRewardGiven = tag.GetBool(nameof(_skeletronRewardGiven));
+    }
+
+    public override void SaveWorldData(TagCompound tag)
+    {
+        tag[nameof(_kingSlimeRewardGiven)] = _kingSlimeRewardGiven;
+        tag[nameof(_eyeOfCthulhuRewardGiven)] = _eyeOfCthulhuRewardGiven;
+        tag[nameof(_eaterOfWorldsRewardGiven)] = _eaterOfWorldsRewardGiven;
+        tag[nameof(_brainOfCthulhuRewardGiven)] = _brainOfCthulhuRewardGiven;
+        tag[nameof(_skeletronRewardGiven)] = _skeletronRewardGiven;
+    }
+
+    public override void PostWorldGen()
+    {
+        ReduceInitialLifeCrystals();
+    }
+
+    public override void PostUpdateWorld()
+    {
+        if (Main.netMode == NetmodeID.MultiplayerClient)
+        {
+            return;
+        }
+
+        var config = ProgressionReforgedConfig.Instance;
+
+        TryGrantBossReward(ref _kingSlimeRewardGiven, NPC.downedSlimeKing, config.KingSlimeLifeCrystals);
+        TryGrantBossReward(ref _eyeOfCthulhuRewardGiven, NPC.downedBoss1, config.EyeOfCthulhuLifeCrystals);
+        TryGrantBossReward(ref _eaterOfWorldsRewardGiven, NPC.downedBoss2 && WorldGen.crimson != true, config.EaterOfWorldsLifeCrystals);
+        TryGrantBossReward(ref _brainOfCthulhuRewardGiven, NPC.downedBoss2 && WorldGen.crimson, config.BrainOfCthulhuLifeCrystals);
+        TryGrantBossReward(ref _skeletronRewardGiven, NPC.downedBoss3, config.SkeletronLifeCrystals);
+    }
+
+    public static int CountLifeCrystals()
+    {
+        int count = 0;
+
+        for (int x = 0; x < Main.maxTilesX; x++)
+        {
+            for (int y = 0; y < Main.maxTilesY; y++)
+            {
+                Tile tile = Main.tile[x, y];
+                if (tile.HasTile && tile.TileType == TileID.Heart && tile.TileFrameX == 0 && tile.TileFrameY == 0)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private static void ReduceInitialLifeCrystals()
+    {
+        var config = ProgressionReforgedConfig.Instance;
+        float multiplier = Math.Clamp(config.InitialLifeCrystalMultiplier, 0f, 1f);
+
+        if (multiplier >= 0.999f)
+        {
+            return;
+        }
+
+        List<Point16> heartLocations = new();
+        for (int x = 0; x < Main.maxTilesX; x++)
+        {
+            for (int y = 0; y < Main.maxTilesY; y++)
+            {
+                Tile tile = Main.tile[x, y];
+                if (tile.HasTile && tile.TileType == TileID.Heart && tile.TileFrameX == 0 && tile.TileFrameY == 0)
+                {
+                    heartLocations.Add(new Point16(x, y));
+                }
+            }
+        }
+
+        if (heartLocations.Count == 0)
+        {
+            return;
+        }
+
+        UnifiedRandom random = WorldGen.genRand ?? Main.rand;
+        int heartsToKeep = (int)Math.Ceiling(heartLocations.Count * multiplier);
+        int heartsToRemove = Math.Max(0, heartLocations.Count - heartsToKeep);
+
+        for (int i = 0; i < heartsToRemove; i++)
+        {
+            int index = random.Next(heartLocations.Count);
+            Point16 topLeft = heartLocations[index];
+            heartLocations.RemoveAt(index);
+
+            RemoveHeartAt(topLeft);
+        }
+    }
+
+    private static void RemoveHeartAt(Point16 topLeft)
+    {
+        for (int xOffset = 0; xOffset < 2; xOffset++)
+        {
+            for (int yOffset = 0; yOffset < 2; yOffset++)
+            {
+                int x = topLeft.X + xOffset;
+                int y = topLeft.Y + yOffset;
+                if (WorldGen.InWorld(x, y))
+                {
+                    WorldGen.KillTile(x, y, noItem: true);
+                }
+            }
+        }
+
+        NetMessage.SendTileSquare(-1, topLeft.X + 1, topLeft.Y + 1, 2);
+    }
+
+    private void TryGrantBossReward(ref bool flag, bool conditionMet, int amount)
+    {
+        if (flag || !conditionMet || amount <= 0)
+        {
+            return;
+        }
+
+        int placed = SpawnLifeCrystals(amount);
+        if (placed > 0)
+        {
+            flag = true;
+        }
+    }
+
+    private int SpawnLifeCrystals(int amount)
+    {
+        int placed = 0;
+        var attemptsPerCrystal = 3000;
+        for (int i = 0; i < amount; i++)
+        {
+            if (TryPlaceLifeCrystal(attemptsPerCrystal))
+            {
+                placed++;
+            }
+        }
+
+        return placed;
+    }
+
+    private bool TryPlaceLifeCrystal(int attempts)
+    {
+        UnifiedRandom random = WorldGen.genRand ?? Main.rand;
+
+        for (int attempt = 0; attempt < attempts; attempt++)
+        {
+            int x = random.Next(50, Main.maxTilesX - 50);
+            int y = random.Next((int)Main.rockLayer, Main.maxTilesY - 200);
+
+            if (!WorldGen.InWorld(x, y, 2))
+            {
+                continue;
+            }
+
+            if (!IsSuitableLifeCrystalLocation(x, y))
+            {
+                continue;
+            }
+
+            if (WorldGen.PlaceTile(x, y, TileID.Heart, mute: true, forced: true))
+            {
+                NetMessage.SendTileSquare(-1, x + 1, y + 1, 2);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsSuitableLifeCrystalLocation(int x, int y)
+    {
+        if (y < Main.worldSurface)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < 2; j++)
+            {
+                Tile tile = Framing.GetTileSafely(x + i, y + j);
+                if (tile.HasTile)
+                {
+                    return false;
+                }
+            }
+        }
+
+        for (int i = -1; i <= 2; i++)
+        {
+            Tile below = Framing.GetTileSafely(x + i, y + 2);
+            if (below.HasTile && Main.tileSolid[below.TileType])
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static int GetLifeCrystalCostForNextHeart(Player player)
+    {
+        var config = ProgressionReforgedConfig.Instance;
+
+        int currentHearts = Math.Max(0, (player.statLifeMax - 100) / 20);
+        int nextHeartIndex = currentHearts + 1;
+
+        int baseCost = Math.Max(1, config.LifeCrystalBaseCost);
+        int frequency = Math.Max(1, config.LifeCrystalCostIncreaseFrequency);
+        int increment = Math.Max(0, config.LifeCrystalCostIncreaseAmount);
+
+        int steps = (nextHeartIndex - 1) / frequency;
+        long cost = baseCost + (long)steps * increment;
+
+        return (int)Math.Clamp(cost, 1, 999);
+    }
+}


### PR DESCRIPTION
## Summary
- expose a world command that reports the number of life crystals currently spawned
- add a helper on the life crystal system to count existing heart tiles for reuse

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e6a3ee2788832cacdb334d8b934117